### PR TITLE
feat: add queries for listing all tickets

### DIFF
--- a/graphql/resolvers/ticket/queries.js
+++ b/graphql/resolvers/ticket/queries.js
@@ -3,6 +3,11 @@
 const Ticket = use('App/Models/Ticket')
 
 const queries = {
+  async tickets () {
+    const tickets = await Ticket.all()
+
+    return tickets.toJSON()
+  },
 
   async listOwnTickets (root, { username }) {
     const list = await Ticket

--- a/graphql/typedefs/index.graphql
+++ b/graphql/typedefs/index.graphql
@@ -1,6 +1,7 @@
 type Query {
   categories: [Category]
   getCategory(id: Int!): Category
+  tickets: [Ticket] 
   listOwnTickets(username: String!): [Ticket]
   ticket(id: Int!): Ticket
 }

--- a/test/functional/ticket.spec.js
+++ b/test/functional/ticket.spec.js
@@ -228,3 +228,28 @@ test('Employee can create/ open new Ticket Support', async ({ client }) => {
     }
   })
 })
+
+test('Admin can view list of all ticket support', async ({ client, assert }) => {
+  await Factory.model('App/Models/Category').createMany(3)
+  await Factory.model('App/Models/Ticket').createMany(5)
+
+  const data = {
+    query: ` 
+      {
+        tickets {
+          id,
+          username,
+          title,
+          category {
+            name
+          }
+        }
+      }
+    `
+  }
+
+  const response = await client.post('/graphql').send(data).end()
+
+  response.assertStatus(200)
+  assert.equal(response.body.data.tickets.length, 5)
+})


### PR DESCRIPTION
Task 11
- Admin can view list of all ticket support.

Note: without auth